### PR TITLE
Restrict to any currently released version of underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/jmeas/backbone.intercept",
   "dependencies": {
     "backbone": ">=0.9.9 <=1.1.2",
-    "underscore": ">=1.3.3 <=1.6.0"
+    "underscore": "<=1.7.0"
   },
   "devDependencies": {
     "backbone.radio": "^0.6.0",


### PR DESCRIPTION
This lib will actually work with `underscore@0.1` as defaults and bind (w/o args) have been around since the start lol xD
