### PR TITLE
in IE8 e.which is always 0 better to catch all mouse clicks then none

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Backbone.Intercept depends on Underscore, Backbone and a jQuery-like API on the 
     - [Navigation](#navigation)
     - [Customizing the Behavior Per-Link](#customizing-the-behavior-per-link)
     - [Setting Global Link Trigger Behavior](#setting-global-link-trigger-behavior)
+    - [Setting Global includeSearch for intercepting also the queryString](#setting-global-includesearch-for-intercepting-also-the-querystring)
   - [Forms](#forms)
   - [Setting the Root Element of Backbone.Intercept](#setting-the-root-element-of-backboneintercept)
   - [When Not to Use Backbone.Intercept](#when-not-to-use-backboneintercept)
@@ -167,6 +168,16 @@ You can set the default trigger behavior by specifying it directly on the Backbo
 Backbone.Intercept.defaults.trigger = false;
 ```
 
+#### Setting Global includeSearch for intercepting also the queryString
+
+You can set the default includeSearch behavior by specifying it directly on the Backbone.Intercept `defaults` option
+the default is false to maintain backward compatibility.
+
+```js
+// Let's set the includeSearch setting to true
+Backbone.Intercept.defaults.includeSearch = true;
+```
+
 ### Forms
 
 Forms are much simpler than links. All forms are intercepted unless the `action` attribute has been specified. And unlike links, there's
@@ -212,9 +223,10 @@ A query selector for the root element of Intercept. Defaults to `'body'`.
 
 ##### `defaults`
 
-An object for the default values for the router. There are three properties in defaults, `links`, `forms`, and `trigger`,
-and all three are `true` out-of-the-box. The first two options determine if Intercept handles links and forms, respectively. The
+An object for the default values for the router. There are four properties in defaults, `links`, `forms`, `trigger` and `includeSearch`
+and all are `true` out-of-the-box except `includeSearch` . The first two options determine if Intercept handles links and forms, respectively. The
 `trigger` option determines if intercepted links pass `trigger:true` by default.
+`includeSearch` option determines if intercepted links pass also the queryString(search) and not only the pathname by default.
 
 The value of the `trigger` or `data-trigger` attribute on the anchor tag itself will always trump the value of the
 value of `trigger` in the `defaults` hash.

--- a/src/backbone.intercept.js
+++ b/src/backbone.intercept.js
@@ -45,8 +45,8 @@ Backbone.Intercept = {
   },
 
   _interceptLinks: function(e) {
-    // Only intercept left-clicks
-    if (e.which !== 1) { return; }
+    // Only intercept left-clicks, in IE8 e.which is always 0
+    if (e.which > 1) { return; }
     var $link = Backbone.$(e.currentTarget);
 
     // Get the href; stop processing if there isn't one

--- a/src/backbone.intercept.js
+++ b/src/backbone.intercept.js
@@ -7,7 +7,8 @@ Backbone.Intercept = {
   defaults: {
     trigger : true,
     links   : true,
-    forms   : true
+    forms   : true,
+    includeSearch: false
   },
 
   start: function(options) {
@@ -83,7 +84,9 @@ Backbone.Intercept = {
     // Get the computed pathname of the link, removing
     // the leading slash. Regex required for IE8 support
     var pathname = $link[0].pathname.replace(/^\//, '');
-
+    if (this.defaults.includeSearch && $link[0].search) {
+      pathname += $link[0].search;//add the query string
+    }
     // Lastly we send off the information to the router
     if (!this.navigate) { return; }
     this.navigate(pathname, navOptions);


### PR DESCRIPTION
backbone.intercept didn't intercept any links on IE8 since jQuery sets e.which to 0 for left click on IE8
didn't create an issue for this but i can if you want me to
