### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/jmeas/backbone.intercept",
   "dependencies": {
-    "backbone": ">=0.9.9 <=1.2.1",
+    "backbone": ">=0.9.9 <=1.2.3",
     "underscore": ">=1.3.3 <=1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
update to latest backbone range, so backbone does not get included twice when using browserify or webpack with Backbone.Intercept + Marionette